### PR TITLE
updated dependencies for laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,17 +20,17 @@
         }
     ],
     "require": {
-        "php": ">=7.0"
+        "php": "^7.2.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "~6.0|~7.0",
-        "squizlabs/php_codesniffer": "^2.3",
-        "mockery/mockery": "~1.0",
+        "phpunit/phpunit": "^8.5",
+        "squizlabs/php_codesniffer": "^3.4",
+        "mockery/mockery": "^1.3.1",
         "moontoast/math": "^1.1",
         "doctrine/inflector": "^1.2",
-        "nesbot/carbon": "^1.26 || ^2.00",
+        "nesbot/carbon": "^2.31.0",
         "ramsey/uuid": "^3.7",
-        "symfony/var-dumper": "~3.3|~4.0"
+        "symfony/var-dumper": "^5.0.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
when required from composer the package gives error that var-dumper is outdated. 
changed var-dumper in other packages for countries.
changed the php version required to 7.2.5 as this is what laravel 7 uses now.
phpunit and codesniffer also require higher version.
i havent tested this as im new to github and dont know how to test this as it is your project.
hope it is to any help.